### PR TITLE
feat/guppy-config

### DIFF
--- a/tube/etl/indexers/base/parser.py
+++ b/tube/etl/indexers/base/parser.py
@@ -32,14 +32,9 @@ class Parser(object):
                 p.update_type(prop.type)
 
     def get_es_types(self):
-        self.types = self.select_widest_types({p.name: p.type
-                                               for p in PropFactory.get_prop_by_doc_name(self.doc_type).values()
-                                               if p.type is not None})
-
-    def select_widest_types(self, types):
-        for k, v in types.items():
-            types[k] = self.select_widest_type(v)
-        return types
+        self.types = {p.name: (self.select_widest_type(p.type), 1 if p.fn in ['set', 'list'] else 0)
+                      for p in PropFactory.get_prop_by_doc_name(self.doc_type).values()
+                      if p.type is not None}
 
     def select_widest_type(self, types):
         if str in types:

--- a/tube/etl/indexers/base/translator.py
+++ b/tube/etl/indexers/base/translator.py
@@ -45,8 +45,10 @@ class Translator(object):
 
     def write(self, df):
         df = self.restore_prop_name(df, PropFactory.list_props)
-        self.writer.write_df(df, self.parser.name,
-                             self.parser.doc_type, self.parser.types)
+        # fix this, found a better way to distinguish between 'file' and 'etl'
+        if self.parser.name == 'etl':
+            self.writer.create_guppy_array_config(self.parser.name, self.parser.types)
+        self.writer.write_df(df, self.parser.name, self.parser.doc_type, self.parser.types)
 
     def get_props_from_data_row(self, df, props, to_tuple=False):
         if df.isEmpty():

--- a/tube/etl/plugins/mapping.py
+++ b/tube/etl/plugins/mapping.py
@@ -1,4 +1,4 @@
 def add_auth_resource_path_mapping(types):
     if 'project_id' in types:
-        types['auth_resource_path'] = str
+        types['auth_resource_path'] = (str, 0)
     return types


### PR DESCRIPTION
Creates a Guppy configuration index with versioning and backups in the following form:

```
{
    "timestamp": "1990-01-01T10:10:10",
    "array": ["gen3-dev-subject.some_string_field", "gen3-dev-subject.some_integer_field"]
}
```

Guppy configuration will always point to the `etl` alias.