### PR TITLE
feat/guppy-config

### DIFF
--- a/tube/etl/indexers/base/translator.py
+++ b/tube/etl/indexers/base/translator.py
@@ -45,9 +45,7 @@ class Translator(object):
 
     def write(self, df):
         df = self.restore_prop_name(df, PropFactory.list_props)
-        # fix this, found a better way to distinguish between 'file' and 'etl'
-        if self.parser.name == 'etl':
-            self.writer.create_guppy_array_config(self.parser.name, self.parser.types)
+        self.writer.create_guppy_array_config(self.parser.name, self.parser.types)
         self.writer.write_df(df, self.parser.name, self.parser.doc_type, self.parser.types)
 
     def get_props_from_data_row(self, df, props, to_tuple=False):

--- a/tube/etl/outputs/es/versioning.py
+++ b/tube/etl/outputs/es/versioning.py
@@ -112,7 +112,6 @@ class Versioning(object):
     def backup_old_index(self, index):
         """
         Create an empty versioned index.
-        :param mapping: mapping for index
         :param index: the name/alias of index
         :return:
         """

--- a/tube/etl/outputs/es/writer.py
+++ b/tube/etl/outputs/es/writer.py
@@ -94,7 +94,8 @@ class Writer(SparkBase):
         :param etl_index_name:
         :param types:
         """
-        index = 'array-config'
+        index = '{}-array-config'.format(etl_index_name)
+        alias = 'array-config'
 
         mapping = {
             'mappings': {
@@ -116,8 +117,9 @@ class Writer(SparkBase):
 
         self.reset_status()
         index_to_write = self.versioning.create_new_index(mapping, self.versioning.backup_old_index(index))
-        self.es.index(index_to_write, '_doc', body=doc)
+        self.es.index(index_to_write, '_doc', id=etl_index_name, body=doc)
         self.versioning.putting_new_version_tag(index_to_write, index)
+        self.versioning.putting_new_version_tag(index_to_write, alias)
         putting_timestamp(self.es, index_to_write)
         self.reset_status()
 


### PR DESCRIPTION
This `tube` changes create Guppy array config for all ETL indices with versioning and backups.