### PR TITLE
Fix error when mapping document have not aggregated_props

### DIFF
--- a/tube/etl/indexers/aggregation/translator.py
+++ b/tube/etl/indexers/aggregation/translator.py
@@ -206,7 +206,10 @@ class Translator(BaseTranslator):
         root_df = self.translate_special(root_df)
         root_df = self.translate_parent(root_df)
         root_df = self.get_direct_children(root_df)
-        return root_df.join(self.aggregate_nested_properties()).mapValues(lambda x: merge_dictionary(x[0], x[1]))
+        if len(self.parser.aggregated_nodes):
+            return root_df.join(self.aggregate_nested_properties()).mapValues(lambda x: merge_dictionary(x[0], x[1]))
+        else:
+            return root_df
 
     def translate_joining_props(self, translators):
         """


### PR DESCRIPTION
Error when missing **aggregated_props** of **niaid_follow_up** in [Etl mapping](https://raw.githubusercontent.com/uc-cdis/cdis-manifest/master/niaid.bionimbus.org/etlMapping.yaml)