### PR TITLE
chore(logs): disable log for performance

### DIFF
--- a/tube/etl/plugins/post_process.py
+++ b/tube/etl/plugins/post_process.py
@@ -40,7 +40,6 @@ def add_auth_resource_path(df):
             program_name, project_code = project_id.split('-', 1)
             resource_path = _get_resource_path_from_yaml(project_code)
             if not resource_path:
-                print("WARNING: Can not get resource path from user.yaml for project code {}".format(project_code))
                 df[1]['auth_resource_path'] = "/programs/{}/projects/{}".format(program_name, project_code)
             else:
                 df[1]['auth_resource_path'] = resource_path


### PR DESCRIPTION
The indexing takes pretty long for the case that the `auth_resource_path` does not exist in `user.yaml`. Besides, `tube` continuously print all the log with the same content everywhere.