### PR TITLE
refactor(dockerfile): split pip install to own layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,9 @@ RUN mkdir -p $ACCUMULO_HOME $HIVE_HOME $HBASE_HOME $HCAT_HOME $ZOOKEEPER_HOME
 
 ENV PATH=${SQOOP_HOME}/bin:${HADOOP_HOME}/sbin:$HADOOP_HOME/bin:${JAVA_HOME}/bin:${PATH}
 
+COPY requirements.txt /tube/
+RUN pip install --no-cache-dir -r /tube/requirements.txt
+
 COPY . /tube
 WORKDIR /tube
 
@@ -82,5 +85,4 @@ WORKDIR /tube
 #RUN chmod +x /tini
 #ENTRYPOINT ["/tini", "--"]
 
-RUN pip install --no-cache-dir -r requirements.txt
 RUN python setup.py develop


### PR DESCRIPTION
Put `RUN pip install blah` before `COPY . /tube` so that the `pip install` layer has its own build cache that comes after the `COPY`. Then changing the tube code without changing the packages will not invalidate the `pip install` cache, so devs can iterate faster, and builds go faster in general. 

https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy

### Improvements
In Dockerfile, split pip install into its own layer to improve build caching