### PR TITLE
fix(long): assign es_type long to all ints

### DIFF
--- a/tube/etl/outputs/es/writer.py
+++ b/tube/etl/outputs/es/writer.py
@@ -34,7 +34,7 @@ class Writer(SparkBase):
         es_type = {
             str: 'keyword',
             float: 'float',
-            int: 'integer'
+            int: 'long'
         }
 
         properties = {


### PR DESCRIPTION
Side note: Arcadia discussed and decided we were okay with reduced indexing latency caused by everything being a long, in exchanged for reduced code complexity by way of not having logic to decide which type to assign.

### Bug Fixes
Map all python ints to es_type long. Fixes bug introduced in py3 migration, in which large python ints that were previously mapped to ES type long were being mapped to ES type int (Py3 merges type long into type int), causing an ES error. 



