### PR TITLE
Add debug log

### DIFF
--- a/tube/etl/indexers/base/parser.py
+++ b/tube/etl/indexers/base/parser.py
@@ -71,7 +71,10 @@ class Parser(object):
         )
 
     def get_prop_by_name(self, name):
-        return PropFactory.get_prop_by_name(self.doc_type, name)
+        prop = PropFactory.get_prop_by_name(self.doc_type, name)
+        if not prop:
+            print("DEBUG: prop '{}' not in '{}'".format(name, self.doc_type))
+        return prop
 
     def get_prop_type(self, fn, src, node_label=None, index=None):
         if fn is not None:


### PR DESCRIPTION
```
ERROR when running transformation
Traceback (most recent call last):
  File "run_etl.py", line 32, in run_transform
    interpreter.run_transform(translators)
  File "/tube/tube/etl/indexers/interpreter.py", line 37, in run_transform
    df = translator.translate()
  File "/tube/tube/etl/indexers/aggregation/translator.py", line 329, in translate
    root_df = self.ensure_project_id_exist(root_df)
  File "/tube/tube/etl/indexers/aggregation/translator.py", line 309, in ensure_project_id_exist
    project_code_id = self.parser.get_prop_by_name(PROJECT_CODE).id
AttributeError: 'NoneType' object has no attribute 'id'
```

### Improvements
- Add debug log to help troubleshoot errors when props are missing
