### PR TITLE
Fix/index parser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # To check running container: docker exec -it tube /bin/bash
-FROM python:3.7-stretch
+FROM quay.io/cdis/python:3.7-stretch
 
 ENV DEBIAN_FRONTEND=noninteractive \
     SQOOP_VERSION="1.4.7" \

--- a/tube/etl/indexers/base/parser.py
+++ b/tube/etl/indexers/base/parser.py
@@ -105,7 +105,10 @@ class Parser(object):
 
     @staticmethod
     def get_src_name(props):
-        lst = [tuple(p.split(":")) if ":" in p else tuple([p, p]) for p in props]
+        lst = [
+            tuple(p.strip().split(":")) if ":" in p else tuple([p.strip()] * 2)
+            for p in props
+        ]
         return lst
 
     def create_prop_from_json(

--- a/tube/etl/indexers/base/parser.py
+++ b/tube/etl/indexers/base/parser.py
@@ -105,6 +105,7 @@ class Parser(object):
 
     @staticmethod
     def get_src_name(props):
+        # debug
         lst = [
             tuple(p.strip().split(":")) if ":" in p else tuple([p.strip()] * 2)
             for p in props


### PR DESCRIPTION
Parsed index names no longer will contain trailing or beginning whitespace. 

### Bug Fixes
Fix bug where whitespace is unintentionally left in name
