### PR TITLE
Update Travis Pipeline to check on quay given a number of attempts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,9 @@ before_script:
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, PR=$PR, BRANCH=$BRANCH"
   - export REPOSITORY=cdis/tube
-  - ./wait_for_quay.sh -r ${REPOSITORY} -b ${BRANCH//\//_} -d 30
+  - export BUILD_STATUS=$(./wait_for_quay.sh -r ${REPOSITORY} -b ${BRANCH//\//_} -d 30 -a 5)
+  - export QUAY_BUILD_STATUS=$(echo $BUILD_STATUS | tr " " "\n" | tail -1)
+  - echo $QUAY_BUILD_STATUS
   - git clone https://github.com/uc-cdis/compose-etl.git --branch master --single-branch
   - cp -f tests/gen3/tube/etlMapping.yaml compose-etl/configs/etlMapping.yaml
   - cp -f tests/gen3/tube/user.yaml compose-etl/configs/user.yaml
@@ -51,7 +53,12 @@ before_script:
       "db_database": "metadata_db"
     }
     ' > configs/creds.json
-  - sed -i "s/tube:master/tube:${BRANCH//\//_}/g" docker-compose.yml
+  - if [[ "$QUAY_BUILD_STATUS" -ne "complete" ]] || [[ "$QUAY_BUILD_STATUS" -eq "null" ]];
+    then {
+      echo  "Could not find the quay build, using default."; };
+    else {
+      echo "Found quay build, updating docker-compose image";
+      sed -i "s/tube:master/tube:${BRANCH//\//_}/g" docker-compose.yml; }; fi
   - sudo sysctl -w vm.max_map_count=262144
   - docker-compose up -d spark elasticsearch
   - sleep 60

--- a/wait_for_quay.sh
+++ b/wait_for_quay.sh
@@ -1,21 +1,28 @@
 #!/bin/bash
 
 QUAY_BUILD_STATUS=""
+ATTEMPTS=5
 
-while getopts r:b:d: option
+while getopts :r:b:d:a: option
 do
   case "${option}"
       in
     r) REPOSITORY=${OPTARG} ;;
     b) BRANCH=${OPTARG} ;;
     d) DELAY=${OPTARG} ;;
+    a) ATTEMPTS=${OPTARG} ;;
   esac
 done
 
-until [ "$QUAY_BUILD_STATUS" == "complete" ]
+CURRENT_ATTEMPT=1
+until [ "$QUAY_BUILD_STATUS" == "complete" ] || [ $CURRENT_ATTEMPT -gt $ATTEMPTS ]
 do
   RESPONSE=$(curl -s -XGET https://quay.io/api/v1/repository/${REPOSITORY}/build/)
   QUAY_BUILD_STATUS=`echo ${RESPONSE} | jq -r '.[] | map(select(.tags[] | contains("'${BRANCH}'")) | {started,phase}) | sort_by(.started) | last | .phase'`
   echo "Quay build status: ${QUAY_BUILD_STATUS}"
+  echo "Attempt number: ${CURRENT_ATTEMPT}"
+  CURRENT_ATTEMPT=$((CURRENT_ATTEMPT + 1))
   sleep $DELAY
 done
+
+echo $QUAY_BUILD_STATUS


### PR DESCRIPTION
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
* Update `wait_for_quay.sh` to support parsing option `-a` for number of attempts
* Update `travis` pipeline to use `-a` option from `wait_for_quay.sh`

### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
