### PR TITLE
PXP-8944 Install `libssl1.0.2` and `libgnutls30` to get updated certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libffi-dev \
     # dependency for cryptography
     libssl-dev \
+    libssl1.0.2 \
+    libgnutls30 \
     vim \
     curl \
     g++ \


### PR DESCRIPTION
Jira Ticket: [PXP-8944](https://ctds-planx.atlassian.net/browse/PXP-8944)

### Dependency updates
- Install `libssl1.0.2` and `libgnutls30` to get updated certs
