### PR TITLE
(PXP-9125): Increase es timeout to 30s

### DIFF
--- a/tube/etl/outputs/es/writer.py
+++ b/tube/etl/outputs/es/writer.py
@@ -40,7 +40,7 @@ class Writer(SparkBase):
         """
         es_hosts = self.es_config["es.nodes"]
         es_port = self.es_config["es.port"]
-        return Elasticsearch([{"host": es_hosts, "port": es_port}])
+        return Elasticsearch([{"host": es_hosts, "port": es_port}], timeout=30)
 
     def write_to_new_index(self, df, index, doc_type):
         df = df.map(lambda x: json_export(x, doc_type))
@@ -99,9 +99,7 @@ class Writer(SparkBase):
 
         doc = {
             "timestamp": latest_transaction_time,
-            "array": [
-                "{}".format(k) for k in array_types
-            ],
+            "array": ["{}".format(k) for k in array_types],
         }
 
         try:


### PR DESCRIPTION
Jira Ticket: [PXP-9125](https://ctds-planx.atlassian.net/browse/PXP-9125)

Please see [ticket comment](https://ctds-planx.atlassian.net/browse/PXP-9125?focusedCommentId=21098) for more detail.

### Bug Fixes
- Increase ElasticSearch Writer client to 30s so that it doesn't time out.