### PR TITLE
fix(auth_resource_path): avoid having array project_name

### DIFF
--- a/tests/gen3/tube/etlMapping.yaml
+++ b/tests/gen3/tube/etlMapping.yaml
@@ -104,3 +104,12 @@ mappings:
           - name: _subject_id
             src: id
           - name: project_id
+  - name: dataset
+    doc_type: project
+    type: aggregator
+    root: project
+    props:
+      - name: code
+      - name: name
+    parent_props:
+      - path: programs[program_name:name]

--- a/tests/test_data/project.json
+++ b/tests/test_data/project.json
@@ -1,0 +1,8 @@
+[
+    {
+        "code": "jenkins",
+        "dbgap_accession_number": "jenkins",
+        "name": "jenkins",
+        "type": "project"
+    }
+]

--- a/tests/test_db/test_db.py
+++ b/tests/test_db/test_db.py
@@ -45,7 +45,8 @@ def test_items_equal_db(filename, total, entries):
 
         prop_json = cur.fetchall()
         prop_json = [item["_props"] for item in prop_json]
-        prop_json = sorted(prop_json, key=itemgetter("submitter_id"))
+        kwy_field = "submitter_id" if filename != "project" else "code"
+        prop_json = sorted(prop_json, key=itemgetter(kwy_field))
 
         for x, y in zip(entries, prop_json):
             keys_x = set(x.keys())

--- a/tests/test_es/test_es.py
+++ b/tests/test_es/test_es.py
@@ -67,7 +67,7 @@ def test_es_types(init_interpreter, doc_type):
     "doc_type", [dt.parser.doc_type for dt in list(init_interpreter().values())]
 )
 def test_get_list_from_path(init_interpreter, doc_type):
-    if doc_type == "file":
+    if doc_type in ["file", "project"]:
         return
     interpreter = init_interpreter
     items = items_in_file(doc_type)[2]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,8 @@ def items_in_file(filename):
 
     with open(in_json_path, "r") as f:
         entries = json.load(f)
-        entries = sorted(entries, key=itemgetter("submitter_id"))
+        key_field = "submitter_id" if filename != "project" else "code"
+        entries = sorted(entries, key=itemgetter(key_field))
     total_entries = len(entries)
 
     return filename, total_entries, entries

--- a/tube/etl/indexers/aggregation/translator.py
+++ b/tube/etl/indexers/aggregation/translator.py
@@ -9,7 +9,7 @@ from tube.etl.indexers.base.lambdas import (
     make_key_from_property,
     merge_aggregate_with_reducer,
     seq_aggregate_with_reducer,
-    flatmap_nested_list_rdd,
+    flatmap_nested_list_rdd, from_program_name_project_code_to_project_id,
 )
 from tube.etl.indexers.base.translator import Translator as BaseTranslator
 from tube.etl.indexers.aggregation.lambdas import (
@@ -402,14 +402,10 @@ class Translator(BaseTranslator):
             )
             project_code_id = self.parser.get_prop_by_name(PROJECT_CODE).id
             program_name_id = self.parser.get_prop_by_name(PROGRAM_NAME).id
+            project_id_id = project_id_prop.id
             df = df.mapValues(
-                lambda x: merge_dictionary(
-                    x,
-                    {
-                        project_id_prop.id: "{}-{}".format(
-                            x.get(program_name_id), x.get(project_code_id)
-                        )
-                    },
+                lambda x: from_program_name_project_code_to_project_id(
+                    x, project_id_id, program_name_id, project_code_id
                 )
             )
         return df

--- a/tube/etl/indexers/aggregation/translator.py
+++ b/tube/etl/indexers/aggregation/translator.py
@@ -9,7 +9,8 @@ from tube.etl.indexers.base.lambdas import (
     make_key_from_property,
     merge_aggregate_with_reducer,
     seq_aggregate_with_reducer,
-    flatmap_nested_list_rdd, from_program_name_project_code_to_project_id,
+    flatmap_nested_list_rdd,
+    from_program_name_project_code_to_project_id,
 )
 from tube.etl.indexers.base.translator import Translator as BaseTranslator
 from tube.etl.indexers.aggregation.lambdas import (

--- a/tube/etl/indexers/base/lambdas.py
+++ b/tube/etl/indexers/base/lambdas.py
@@ -314,3 +314,18 @@ def flatmap_nested_list_rdd(x):
         else:
             res.append((x0, x1, x2))
     return tuple(res)
+
+
+def from_program_name_project_code_to_project_id(x, project_id_id, program_name_id, project_code_id):
+    programs = x.get(program_name_id)
+    if not isinstance(programs, list):
+        programs = [programs]
+    projects = x.get(project_code_id)
+    if not isinstance(projects, list):
+        projects = [projects]
+
+    list_project_ids = ["{}-{}".format(pg, pj) for pg in programs for pj in projects]
+    if len(list_project_ids) == 1:
+        list_project_ids = list_project_ids[0]
+
+    return merge_dictionary(x, {project_id_id: list_project_ids})


### PR DESCRIPTION
Jira Ticket: [PXP-9659](https://ctds-planx.atlassian.net/browse/PXP-9659)
### Bug Fixes
A bug was introduced in Tube for the creation of indices with the project node as root. In PRC QA and Prod, we cannot access the data because the auth_resource_path is wrong:

"auth_resource_path" : "/programs/['open']/projects/Com-Mobility"

We fixed that by checking the array type of data during the translation
