### PR TITLE
fix(none): fix to check mismatch field

### DIFF
--- a/tube/etl/indexers/base/parser.py
+++ b/tube/etl/indexers/base/parser.py
@@ -133,6 +133,8 @@ class Parser(object):
 
     def get_prop_type_of_field_in_dictionary(self, node_label, prop):
         node_prop = self.dictionary.schema.get(node_label).get("properties").get(prop)
+        if node_prop is None:
+            raise Exception(f"Field {prop} is not presenting in {node_label}")
         some_of = node_prop.get("anyOf") or node_prop.get("oneOf")
         try:
             if "type" not in node_prop and some_of is not None:

--- a/tube/etl/indexers/base/parser.py
+++ b/tube/etl/indexers/base/parser.py
@@ -134,7 +134,8 @@ class Parser(object):
     def get_prop_type_of_field_in_dictionary(self, node_label, prop):
         node_prop = self.dictionary.schema.get(node_label).get("properties").get(prop)
         if node_prop is None:
-            raise Exception(f"Field {prop} is not presenting in {node_label}")
+            print(f"WARN: Field {prop} is not presenting in {node_label}")
+            return (str,)
         some_of = node_prop.get("anyOf") or node_prop.get("oneOf")
         try:
             if "type" not in node_prop and some_of is not None:


### PR DESCRIPTION
Jira Ticket: [PXP-9846](https://ctds-planx.atlassian.net/browse/PXP-9846)

### Bug Fixes
Currently, in some etlMapping file, there is an explicit declaration of field like `source_node` which should not be since this field is only an additional field add into file etl to annotate the node where the file from.
We put a check and log with WARN in code to skip this field when there are some fields like that in etlMapping.
