### PR TITLE
fix github action

### DIFF
--- a/.github/workflows/image_build_and_test.yaml
+++ b/.github/workflows/image_build_and_test.yaml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Extract branch name
         shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF_NAME})"
         id: extract_branch
 
       - name: Copy configuration files


### PR DESCRIPTION
Jira Ticket: [PXP-10571](https://ctds-planx.atlassian.net/browse/PXP-10571)

Github action change the way to get the current branch. This change to adapt the new change from github

[PXP-10571]: https://ctds-planx.atlassian.net/browse/PXP-10571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PXP-10571]: https://ctds-planx.atlassian.net/browse/PXP-10571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ